### PR TITLE
Fix parameters with - and remove content to shortcode

### DIFF
--- a/type/block.php
+++ b/type/block.php
@@ -79,6 +79,7 @@ class WP_Super_Duper_Block {
 					$value = implode( ',', $value );
 				}
 				$key   = sanitize_title_with_dashes( $key );
+				$key   = str_replace( '__', '-', $key );
 				$value = wp_slash( $value );
 				$attributes .= " $key='$value' ";
 			}
@@ -342,11 +343,13 @@ class WP_Super_Duper_Block {
 
 							if (( !is_fetching && JSON.stringify(prev_attributes[props.id]) != JSON.stringify(props.attributes) ) || $refresh) {
 
+								var attributes = props.attributes;
+								delete attributes['content'];
 								is_fetching = true;
 								var data = {
 									'action': 'super_duper_output_shortcode',
 									'shortcode': '<?php echo $this->sd->options['base_id'];?>',
-									'attributes': props.attributes,
+									'attributes': attributes,
 									'post_id': <?php global $post; if ( isset( $post->ID ) ) {
 									echo $post->ID;
 								} else {


### PR DESCRIPTION
As today the parameter with `__` are not revert back as `-` in the preview.
Also I saw that the content parameter of the shortcode is sent to the rendering but is unused as parameter and is something private. Also passing content generate hundreds of shortcode parameter as it parses the HTML and create a bit of mess.
There is any hope for a fast release with those fix?