### PR TITLE
Fusion Builder tab errors when SD block group name contains special characters (like \/' etc) - FIXED

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,3 +1,6 @@
+= 1.2.33 - 2026-06-TBD =
+* Fusion Builder tab errors when SD block group name contains special characters (like \/' etc) - FIXED
+
 = 1.2.32 - 2026-06-10 =
 * Disable additional CSS option for SD blocks - CHANGED
 

--- a/wp-super-duper.php
+++ b/wp-super-duper.php
@@ -240,6 +240,16 @@ if ( ! class_exists( 'WP_Super_Duper' ) ) {
 					// Group
 					if ( isset( $val['group'] ) ) {
 						$param['group'] = $val['group'];
+
+						if ( ! empty( $param['group'] ) ) {
+							// Fusion Builder converts the group name into a tab ID without sanitization and assigns it to the href.
+							// Replace some punctuation symbols.
+							$param['group'] = preg_replace( '/[\&,\(\)\:\/\\\\]/u', ' ', $param['group'] );
+							// Remove ' ".
+							$param['group'] = preg_replace( '/[\'\"]/u', '', $param['group'] );
+							// Replace consecutive spaces with single space.
+							$param['group'] = preg_replace( '/\s+/', ' ', $param['group'] );
+						}
 					}
 
 					// value


### PR DESCRIPTION
Fixes https://github.com/AyeCode/geodirectory/issues/3041